### PR TITLE
Add the chord_intervals() method

### DIFF
--- a/lib/Music/Chord/Note.pm
+++ b/lib/Music/Chord/Note.pm
@@ -151,6 +151,18 @@ sub chord_num
     return split /,/, $base_chord_list->{$chord};
 }
 
+sub chord_intervals
+{
+    my ($self, $name) = @_;
+
+    my @num = $self->chord_num($name);
+
+    my @intervals = reverse map { $_ == 0 ? $num[$_] : $num[$_] - $num[$_ - 1] }
+        reverse 0 .. $#num;
+
+    return @intervals;
+}
+
 sub scale
 {
     my $self = shift;
@@ -197,6 +209,10 @@ Music::Chord::Note - get Chord Tone List from Chord Name
 
     print "@tone_num"; # 0 4 7 11
 
+    my @intervals = $cn->chord_intervals('M7');
+
+    print "@intervals"; # 0 4 3 4
+
     my $note = $cn->scale('D#');
 
     print "$note"; # 3
@@ -221,6 +237,10 @@ get tone list from chord name with octave for MIDI
 =item chord_num($kind_of_chord)
 
 get scalic value list(ex. M7 -> 0 4 7 11)
+
+=item chord_intervals($chord_name)
+
+get relative scalic value list(ex. M7 -> 0 4 3 4)
 
 =item scale($note)
 

--- a/t/03.chord_intervals.t
+++ b/t/03.chord_intervals.t
@@ -1,0 +1,29 @@
+use strict;
+use warnings;
+use Test::More;
+
+use Music::Chord::Note;
+
+my $cn = Music::Chord::Note->new;
+
+{
+    my @intervals = $cn->chord_intervals('');
+    is "@intervals", '0 4 3';
+}
+
+{
+    my @intervals = $cn->chord_intervals('m');
+    is "@intervals", '0 3 4';
+}
+
+{
+    my @intervals = $cn->chord_intervals('M7');
+    is "@intervals", '0 4 3 4';
+}
+
+{
+    eval { $cn->chord_intervals('X'); };
+    like($@, qr/undefined kind of chord/);
+}
+
+done_testing();


### PR DESCRIPTION
Hi bayashi-san. This algorithm is similar to `chord_num()`, but shows the intervals of a chord **relative** to the previous pitch. It's from a fellow musician, and I thought it would fit nicely in Music::Chord::Note. :)